### PR TITLE
Release node 6.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.5.0" %}
+{% set version = "6.6.0" %}
 
 package:
   name: nodejs
@@ -7,7 +7,7 @@ package:
 source:
   fn: node-v{{ version }}.tar.gz
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}.tar.gz
-  sha256: 74ced83b8d890d90e2a8b0d54b0d0e9b5e01d6fd6148cec6e9911ff6eaf0cf21
+  sha256: 11b957de855a392ceaa8b300ec66236d6f9c6baa184837d00bdaba2da4aefe91
 
 build:
   number: 0


### PR DESCRIPTION
How do we get the same base-language-version support for node, ruby, etc. packages that we have for Python? e.g. a node package should have a node44 marker just like we have py35. Same goes for Ruby and any other language package. Do we use features for this?

Marking as WIP, because I think merging this will break all node packages because they lack this feature, so the fact that they require the nodejs they were built with is not recorded.
