### PR TITLE
upgrade and dedupe npm

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,4 +8,12 @@ make install
 
 node -v
 npm version
+# upgrade npm
+npm install -g npm@5.0
+# dedupe npm itself to get some slight protection from long paths on Windows
+# Unclear why npm doesn't do this by default
+# when it does for packages other than itself.
+cd $PREFIX/lib/node_modules/npm
+npm dedupe
 
+npm version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 821f518c9b25b7dc52c4d87fce4dbf6df3227aba92f0d008ec9d1f32e5f603d9
 
 build:
-  number: 0
+  number: 1
   ignore_prefix_files:
     - bin/node
 


### PR DESCRIPTION
might help stave off long path issues on Windows, at least where the cutoff was close.

I think this is the best we can do toward closing #12 without trying something too drastic.