### PR TITLE
[6.x] 6.12.2 fix dedupe command on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,24 +35,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,7 +10,7 @@ COPY Release\node.exe %PREFIX%\node.exe
 
 %PREFIX%\node.exe -v
 %PREFIX%\node.exe deps\npm\cli.js install deps\npm -gf
-%PREFIX%\npm.cmd version
+cmd /c %PREFIX%\npm.cmd version
 REM dedupe npm to avoid too-long path issues on Windows
 cd %PREFIX%\node_modules\npm
-%PREFIX%\npm.cmd dedupe
+cmd /c %PREFIX%\npm.cmd dedupe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.12.0" %}
+{% set version = "6.12.2" %}
 
 package:
   name: nodejs
@@ -7,10 +7,10 @@ package:
 source:
   fn: node-v{{ version }}.tar.gz
   url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}.tar.gz
-  sha256: 05d31c82cabca32f2fe15a1a335899467796396efeca8bdcd5b86621fd2ee319
+  sha256: 1bb1d3a033d69ccfa4051ffa79bedad9bcfd43bc0d4b2b6678c3e53883bfd6eb
 
 build:
-  number: 1
+  number: 0
   ignore_prefix_files:
     - bin/node
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 05d31c82cabca32f2fe15a1a335899467796396efeca8bdcd5b86621fd2ee319
 
 build:
-  number: 0
+  number: 1
   ignore_prefix_files:
     - bin/node
 


### PR DESCRIPTION
calling .cmd files directly exits script immediately, must use cmd /c

same fix is in #19