### PR TITLE
redistribute binary node.js on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,3 +4,4 @@ COPY npm.cmd %PREFIX%\npm.cmd
 COPY npx %PREFIX%\npx
 COPY npx.cmd %PREFIX%\npx.cmd
 ROBOCOPY node_modules %PREFIX%\node_modules /s /e
+if %ERRORLEVEL% LSS 8 exit 0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,19 +1,6 @@
-if "%ARCH%"=="32" (
-   set PLATFORM=x86
-) else (
-  set PLATFORM=x64
-)
-:: Remove -GL from CXXFLAGS as whole program optimization takes too much time and memory
-set "CFLAGS= -MD"
-set "CXXFLAGS= -MD"
-
-call vcbuild.bat nosign nosnapshot no-cctest release %PLATFORM%
-
-COPY Release\node.exe %PREFIX%\node.exe
-
-%PREFIX%\node.exe -v
-%PREFIX%\node.exe deps\npm\bin\npm-cli.js install deps\npm -gf
-cmd /c %PREFIX%\npm.cmd version
-REM dedupe npm to avoid too-long path issues on Windows
-cd %PREFIX%\node_modules\npm
-cmd /c %PREFIX%\npm.cmd dedupe
+COPY node.exe %PREFIX%\node.exe
+COPY npm %PREFIX%\npm
+COPY npm.cmd %PREFIX%\npm.cmd
+COPY npx %PREFIX%\npx
+COPY npx.cmd %PREFIX%\npx.cmd
+ROBOCOPY node_modules %PREFIX%\node_modules /s /e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,10 +6,12 @@ package:
 
 source:
   fn: node-v{{ version }}.tar.gz
-  url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}.tar.gz
-  sha256: 45835c210955cd05cab259e664cc19a6f2748dbda6bc9e13edc9a2e8cc498770
+  url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}.tar.gz  # [not win]
+  sha256: 45835c210955cd05cab259e664cc19a6f2748dbda6bc9e13edc9a2e8cc498770  # [not win]
+  url: https://nodejs.org/dist/v{{ version }}/node-v{{ version }}-win-x64.zip  # [win]
+  sha256: c39e711aebe678455fa74edf6d8f6184d6d93e20f160197799040a0c17005dba  # [win]
   patches:
-    - macosx-target.patch
+    - macosx-target.patch  # [not win]
 
 build:
   number: 0
@@ -20,8 +22,7 @@ requirements:
   build:
     - {{ compiler('c') }}  # [not win]
     - {{ compiler('cxx') }}  # [not win]
-    - python 2.7.*
-    - nasm  # [win]
+    - python 2.7.*  # [not win]
   host:
     - vs2015_runtime  # [win]
   run:


### PR DESCRIPTION
instead of compiling from source due to resource limits (#65)

still compile from source on non-Windows