### PR TITLE
add 16.x to bot branches

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -10,5 +10,5 @@ conda_forge_output_validation: true
 test_on_native_only: true
 bot:
   abi_migration_branches:
-    - "12.x"
+    - "16.x"
     - "14.x"


### PR DESCRIPTION
drop 12.x, so we have 2 LTS active at a time

12.x EOL isn't technically until 2022-04-30, but keeping 2 LTS at a time more closely matches conda-forge patterns for Python versions.
