### PR TITLE
Update to Node.js 24.14.1

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,12 +1,6 @@
-c_compiler:
-- vs2022
-c_stdlib:
-- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cxx_compiler:
-- vs2022
 target_platform:
 - win-64

--- a/.ci_support/win_arm64_.yaml
+++ b/.ci_support/win_arm64_.yaml
@@ -1,12 +1,6 @@
-c_compiler:
-- vs2022
-c_stdlib:
-- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cxx_compiler:
-- vs2022
 target_platform:
 - win-arm64

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -19,22 +19,23 @@ jobs:
     timeout-minutes: 360
     strategy:
       fail-fast: false
+      max-parallel: 50
       matrix:
         include:
           - CONFIG: linux_64_
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-large--${{ github.run_id }}-linux_64_', 'linux', 'x64', 'self-hosted']
+            runs_on: ['cirun-openstack-cpu-large--${{ github.run_id }}-linux_64_']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-large--${{ github.run_id }}-linux_aarch64_', 'linux', 'x64', 'self-hosted']
+            runs_on: ['cirun-openstack-cpu-large--${{ github.run_id }}-linux_aarch64_']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: osx_arm64_
             UPLOAD_PACKAGES: True
             os: macos
-            runs_on: ['cirun-macos-m4-large--${{ github.run_id }}-osx_arm64_', 'macOS', 'arm64', 'self-hosted']
+            runs_on: ['cirun-macos-m4-large--${{ github.run_id }}-osx_arm64_']
     steps:
 
     - name: Checkout code
@@ -108,7 +109,7 @@ jobs:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
         CONDA_BLD_DIR: C:\bld
-        MINIFORGE_HOME: D:\Miniforge
+        MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -20,6 +20,7 @@ export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+export RATTLER_CACHE_DIR="${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache"
 
 cat >~/.condarc <<CONDARC
 

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -11,6 +11,8 @@ source .scripts/logging_utils.sh
 
 set -xeo pipefail
 
+DOCKER_EXECUTABLE="${DOCKER_EXECUTABLE:-docker}"
+
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename "$THISDIR")"
 
@@ -27,7 +29,7 @@ if [[ "${sha:-}" == "" ]]; then
   popd
 fi
 
-docker info
+${DOCKER_EXECUTABLE} info
 
 # In order for the conda-build process in the container to write to the mounted
 # volumes, we need to run with the same id as the host machine, which is
@@ -35,6 +37,7 @@ docker info
 export HOST_USER_ID=$(id -u)
 # Check if docker-machine is being used (normally on OSX) and get the uid from
 # the VM
+
 if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
     export HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
 fi
@@ -76,16 +79,34 @@ if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
-( endgroup "Configure Docker" ) 2> /dev/null
+# Default volume suffix for Docker (preserve original behavior)
+VOLUME_SUFFIX=",z"
 
+# Podman-specific handling
+if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
+    # Fix file permissions for rootless podman builds
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${ARTIFACTS}"
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${RECIPE_ROOT}"
+
+    # Add SELinux label only if enforcing
+    if command -v getenforce &>/dev/null && [ "$(getenforce)" = "Enforcing" ]; then
+        VOLUME_SUFFIX=",z"
+    else
+        VOLUME_SUFFIX=""
+    fi
+fi
+
+( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
-docker pull "${DOCKER_IMAGE}"
-docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
+
+${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
+
+${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/build-locally.py
+++ b/build-locally.py
@@ -28,13 +28,6 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
-    # The default cache location might not be writable using docker on macOS.
-    if ns.config.startswith("linux") and platform.system() == "Darwin":
-        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
-            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
-            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
-        )
-
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "nodejs-feedstock"
-version = "3.55.1"  # conda-smithy version used to generate this file
+version = "3.58.0"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/nodejs-feedstock"
 authors = ["@conda-forge/nodejs"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "24.14.0"
+  version: "24.14.1"
   # NODE_MODULE_VERSION set in src/node_version.h
   NODE_MODULE_VERSION: 137
 
@@ -14,7 +14,7 @@ source:
   - if: unix
     then:
       url: https://nodejs.org/dist/v${{ version }}/node-v${{ version }}.tar.gz
-      sha256: 852c73dd5b6ba15b231d036da6312dbcdabd6295adc3940586f3187b77731cf3
+      sha256: 8298cf1f5774093ca819f41b8dd392fd2cff058688b4d5c8805026352e2d31b3
       patches:
         - patches/0001-stop-removing-librt.patch
         - patches/0002-include-obj-name-in-shared-intermediate.patch
@@ -22,11 +22,11 @@ source:
   - if: target_platform == "win-64"
     then:
       url: https://nodejs.org/dist/v${{ version }}/node-v${{ version }}-win-x64.zip
-      sha256: 313fa40c0d7b18575821de8cb17483031fe07d95de5994f6f435f3b345f85c66
+      sha256: 6e50ce5498c0cebc20fd39ab3ff5df836ed2f8a31aa093cecad8497cff126d70
   - if: target_platform == "win-arm64"
     then:
       url: https://nodejs.org/dist/v${{ version }}/node-v${{ version }}-win-arm64.zip
-      sha256: 88d36e8109736a2fa9bdc596f2cf507a3c52c69cdf96e54f8acd473ec14be853
+      sha256: a7b7c68490e4a8cde1921fe5a0cfb3001d53f9c839e416903e4f28e727b62f60
 
 build:
   number: 0


### PR DESCRIPTION
This PR updates the Node.js version to 24.14.1.

Changes:
- Updated version to 24.14.1
- Updated source tarball sha256
- Reset build number to 0
- Re-rendered with conda-smithy
