### PR TITLE
Update to Node.js 24.16.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,6 +12,7 @@ jobs:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -13,6 +13,11 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
         store_build_artifacts: false
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,9 +11,11 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_arm64_:
         CONFIG: win_arm64_
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-large
+- namespace-profile-16cpu-on-linux-64
 icu:
 - '78'
 libsqlite:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -19,9 +19,9 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-large
+- namespace-profile-8cpu-on-linux-aarch64
 icu:
 - '78'
 libsqlite:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.15'
+- '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
 brotli:
@@ -13,7 +13,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.15'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -22,8 +22,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '19'
-github_actions_labels:
-- cirun-macos-m4-large
 icu:
 - '78'
 libsqlite:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -26,19 +26,14 @@ jobs:
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-large--${{ github.run_id }}-linux_64_']
+            runs_on: ['namespace-profile-16cpu-on-linux-64']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-large--${{ github.run_id }}-linux_aarch64_']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-          - CONFIG: osx_arm64_
-            STORE_BUILD_ARTIFACTS: False
-            UPLOAD_PACKAGES: True
-            os: macos
-            runs_on: ['cirun-macos-m4-large--${{ github.run_id }}-osx_arm64_']
+            runs_on: ['namespace-profile-8cpu-on-linux-aarch64']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
     steps:
 
     - name: Checkout code

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,16 +23,19 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['cirun-openstack-cpu-large--${{ github.run_id }}-linux_64_']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['cirun-openstack-cpu-large--${{ github.run_id }}-linux_aarch64_']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: osx_arm64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: macos
             runs_on: ['cirun-macos-m4-large--${{ github.run_id }}-osx_arm64_']
@@ -108,7 +111,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -15,7 +15,6 @@ github:
   branch_name: main
   tooling_branch_name: main
 github_actions:
-  self_hosted: true
   triggers:
   - push
   - pull_request

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,8 +5,6 @@ bot:
   - 22.x
   automerge: true
 build_platform:
-  linux_aarch64: linux_64
-  osx_arm64: osx_arm64
   win_arm64: win_64
 conda_build:
   pkg_format: '2'
@@ -26,5 +24,6 @@ linter:
   - lint_stdlib
 provider:
   linux_64: github_actions
-  osx_arm64: github_actions
+  linux_aarch64: github_actions
+  osx_arm64: default
 test: native_and_emulated

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "nodejs-feedstock"
-version = "3.58.0"  # conda-smithy version used to generate this file
+version = "3.61.2"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/nodejs-feedstock"
 authors = ["@conda-forge/nodejs"]
 channels = ["conda-forge"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ version = "3.61.2"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/nodejs-feedstock"
 authors = ["@conda-forge/nodejs"]
 channels = ["conda-forge"]
-platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"]
 requires-pixi = ">=0.59.0"
 
 [dependencies]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,10 @@
 c_stdlib_version:                                   # [(osx and x86_64) or linux]
   - '10.15'                                         # [osx and x86_64]
   - "2.28"                                          # [linux]
-github_actions_labels:          # [linux or (osx and arm64)]
-- cirun-openstack-cpu-large     # [linux]
-- cirun-macos-m4-large          # [osx and arm64]
+github_actions_labels:                      # [linux]
+- namespace-profile-16cpu-on-linux-64       # [linux64]
+- namespace-profile-8cpu-on-linux-aarch64   # [linux and aarch64]
+
 MACOSX_SDK_VERSION:  # [osx and x86_64]
   - "11.0"           # [osx and x86_64]
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,4 @@
-c_stdlib_version:                                   # [(osx and x86_64) or linux]
-  - '10.15'                                         # [osx and x86_64]
+c_stdlib_version:                                   # [linux]
   - "2.28"                                          # [linux]
 github_actions_labels:                      # [linux]
 - namespace-profile-16cpu-on-linux-64       # [linux64]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "24.14.1"
+  version: "24.16.0"
   # NODE_MODULE_VERSION set in src/node_version.h
   NODE_MODULE_VERSION: 137
 
@@ -14,7 +14,7 @@ source:
   - if: unix
     then:
       url: https://nodejs.org/dist/v${{ version }}/node-v${{ version }}.tar.gz
-      sha256: 8298cf1f5774093ca819f41b8dd392fd2cff058688b4d5c8805026352e2d31b3
+      sha256: f511d32e3876cb54fa6ddccaa8dd46649ae6ebe9e499c57531c5ca56e7ad4548
       patches:
         - patches/0001-stop-removing-librt.patch
         - patches/0002-include-obj-name-in-shared-intermediate.patch
@@ -22,11 +22,11 @@ source:
   - if: target_platform == "win-64"
     then:
       url: https://nodejs.org/dist/v${{ version }}/node-v${{ version }}-win-x64.zip
-      sha256: 6e50ce5498c0cebc20fd39ab3ff5df836ed2f8a31aa093cecad8497cff126d70
+      sha256: edaca9bd58ec8e92037dac4e877d52f6b8f430b81c18b57e264b4e2fb111cd56
   - if: target_platform == "win-arm64"
     then:
       url: https://nodejs.org/dist/v${{ version }}/node-v${{ version }}-win-arm64.zip
-      sha256: a7b7c68490e4a8cde1921fe5a0cfb3001d53f9c839e416903e4f28e727b62f60
+      sha256: 14834611d4c6b3c06054e7007732b90474c16e0b32f395e05b55a571ef71c6d2
 
 build:
   number: 0


### PR DESCRIPTION
This PR updates the Node.js version to 24.16.0.

Changes:
- Updated version to 24.16.0
- Updated source tarball sha256
- Reset build number to 0
- Re-rendered with conda-smithy
